### PR TITLE
Add the ability to specify common metric attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ $ go install github.com/ipni/fdbmeter/cmd/fdbmeter@latest
 ```shell
 $ fdbmeter --help
 Usage of fdbmeter
+  -commonAttributes string
+        The common attributes to apply to all metrices specified as comma separated key=value.
   -fdbApiVersion int
         The FoundationDB API version. (default 710)
   -fdbClusterFile string

--- a/cmd/fdbmeter/main.go
+++ b/cmd/fdbmeter/main.go
@@ -6,9 +6,11 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"github.com/masih/fdbmeter"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func main() {
@@ -16,13 +18,26 @@ func main() {
 	fdbApiVersion := flag.Int("fdbApiVersion", 710, "The FoundationDB API version.")
 	fdbClusterFile := flag.String("fdbClusterFile", "", "Path to the FoundationDB cluster file.")
 	statusRefreshInterval := flag.Duration("statusRefreshInterval", 10*time.Second, "The interval at which to refresh the FoundationDB status.")
+	commonAttributes := flag.String("commonAttributes", "", "The common attributes to apply to all metrices specified as comma separated key=value.")
 	flag.Parse()
 
+	var commonAttrs []attribute.KeyValue
+	if *commonAttributes != "" {
+		attrString := strings.Split(*commonAttributes, ",")
+		for _, attr := range attrString {
+			kv := strings.Split(attr, "=")
+			if len(kv) != 2 {
+				log.Fatalf("Invalid common attributes: '%s'. Expected exactly one key and one value per comma separated attribute.", attr)
+			}
+			commonAttrs = append(commonAttrs, attribute.String(kv[0], kv[1]))
+		}
+	}
 	meter, err := fdbmeter.New(
 		fdbmeter.WithHttpListenAddr(*httpListenAddr),
 		fdbmeter.WithFdbApiVersion(*fdbApiVersion),
 		fdbmeter.WithFdbClusterFile(*fdbClusterFile),
 		fdbmeter.WithStatusRefreshInterval(*statusRefreshInterval),
+		fdbmeter.WithCommonAttributes(commonAttrs...),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/fdbmeter.go
+++ b/fdbmeter.go
@@ -28,7 +28,7 @@ func New(o ...Option) (*FDBMeter, error) {
 	if err != nil {
 		return nil, err
 	}
-	metrics, err := NewMetrics()
+	metrics, err := NewMetrics(opts.commonAttributes...)
 	if err != nil {
 		return nil, err
 	}

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package fdbmeter
 
-import "time"
+import (
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+)
 
 type (
 	Option  func(*options) error
@@ -9,6 +13,7 @@ type (
 		fdbApiVersion         int
 		fdbClusterFile        string
 		statusRefreshInterval *time.Ticker
+		commonAttributes      []attribute.KeyValue
 	}
 )
 
@@ -32,21 +37,31 @@ func WithHttpListenAddr(a string) Option {
 		return nil
 	}
 }
+
 func WithFdbApiVersion(v int) Option {
 	return func(o *options) error {
 		o.fdbApiVersion = v
 		return nil
 	}
 }
+
 func WithFdbClusterFile(cf string) Option {
 	return func(o *options) error {
 		o.fdbClusterFile = cf
 		return nil
 	}
 }
+
 func WithStatusRefreshInterval(d time.Duration) Option {
 	return func(o *options) error {
 		o.statusRefreshInterval = time.NewTicker(d)
+		return nil
+	}
+}
+
+func WithCommonAttributes(a ...attribute.KeyValue) Option {
+	return func(o *options) error {
+		o.commonAttributes = a
 		return nil
 	}
 }


### PR DESCRIPTION
Implement the ability to specify a set of common key-value attributes as
 command-line argument to then be applied to all exposed metrics.