### PR TITLE
Include all string attributes unless skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 * Periodically fetches and caches FoundationDB status.
 * Exposes a REST endpoint at `/status` to serve the raw JSON for further debugging.
 * Supports custom struct tags to customize metric reporting using the key `fdbmeter`; see [`model`](model.go).
-  * `fdbmeter:"attr"` explicitly includes a `string` field as an attribute.
-    * Note that strings in array or map are automatically added as Prometheus metric attributes.
   * `fdbmeter:"skip"` excludes a field from metric reporting or an attribute. 
   * `fdbmeter:"key=<custom-key>"` customizes the `key` attribute of `map` fields.
 ## Metrics

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -25,7 +25,20 @@ func TestMetricsPopulatesValues(t *testing.T) {
 					},
 				},
 				"cluster_data_state_healthy": {
-					{int64Value: 0, attrs: attribute.NewSet(attribute.String("description", "Only one replica remains of some data"), attribute.String("name", "healing"))},
+					{int64Value: 0, attrs: attribute.NewSet(
+						attribute.String("active_primary_dc", "abc"),
+						attribute.String("description", "Only one replica remains of some data"),
+						attribute.String("name", "healing"),
+						attribute.String("protocol_version", "fdb00b071010000"),
+					)},
+				},
+				"cluster_qos_performance_limited_by_reason_id": {
+					{int64Value: 1, attrs: attribute.NewSet(
+						attribute.String("active_primary_dc", "abc"),
+						attribute.String("description", "Storage server performance (storage queue)."),
+						attribute.String("name", "storage_server_write_queue_size"),
+						attribute.String("protocol_version", "fdb00b071010000"),
+					)},
 				},
 			},
 		},
@@ -35,13 +48,19 @@ func TestMetricsPopulatesValues(t *testing.T) {
 				"cluster_workload_operations_writes_hz": {
 					{
 						float64Value: 342887,
-						attrs:        attribute.NewSet(),
+						attrs: attribute.NewSet(
+							attribute.String("active_primary_dc", ""),
+							attribute.String("protocol_version", "fdb00b071010000"),
+						),
 					},
 				},
 				"cluster_latency_probe_immediate_priority_transaction_start_seconds": {
 					{
 						float64Value: 0.6852229999999999,
-						attrs:        attribute.NewSet(),
+						attrs: attribute.NewSet(
+							attribute.String("active_primary_dc", ""),
+							attribute.String("protocol_version", "fdb00b071010000"),
+						),
 					},
 				},
 			},

--- a/model.go
+++ b/model.go
@@ -3,7 +3,7 @@ package fdbmeter
 type Status struct {
 	Client struct {
 		ClusterFile struct {
-			Path     string `json:"path"`
+			Path     string `json:"path" fdbmeter:"skip"`
 			UpToDate bool   `json:"up_to_date"`
 		} `json:"cluster_file"`
 		Coordinators struct {
@@ -67,7 +67,7 @@ type Status struct {
 			TenantMode                     string `json:"tenant_mode"`
 			UsableRegions                  int    `json:"usable_regions"`
 		} `json:"configuration"`
-		ConnectionString string `json:"connection_string"`
+		ConnectionString string `json:"connection_string" fdbmeter:"skip"`
 		Data             struct {
 			AveragePartitionSizeBytes             int   `json:"average_partition_size_bytes"`
 			LeastOperatingSpaceBytesLogServer     int64 `json:"least_operating_space_bytes_log_server"`
@@ -80,10 +80,10 @@ type Status struct {
 			} `json:"moving_data"`
 			PartitionsCount int `json:"partitions_count"`
 			State           struct {
-				Description          string `json:"description" fdbmeter:"attr"`
+				Description          string `json:"description"`
 				Healthy              bool   `json:"healthy"`
 				MinReplicasRemaining int    `json:"min_replicas_remaining"`
-				Name                 string `json:"name" fdbmeter:"attr"`
+				Name                 string `json:"name"`
 			} `json:"state"`
 			SystemKvSizeBytes int `json:"system_kv_size_bytes"`
 			TeamTrackers      []struct {
@@ -123,7 +123,7 @@ type Status struct {
 			TransactionStartSeconds                  float64 `json:"transaction_start_seconds"`
 		} `json:"latency_probe"`
 		Layers struct {
-			Error string `json:"_error" fdbmeter:"attr"`
+			Error string `json:"_error"`
 			Valid bool   `json:"_valid"`
 		} `json:"layers"`
 		Logs []struct {

--- a/testdata/status1.json
+++ b/testdata/status1.json
@@ -33,7 +33,7 @@
     "timestamp": 1686137027
   },
   "cluster": {
-    "active_primary_dc": "",
+    "active_primary_dc": "abc",
     "active_tss_count": 0,
     "bounce_impact": {
       "can_clean_bounce": true


### PR DESCRIPTION
Do not limit attribute generation from string fields to the ones that are nested in map or slice. This removes the need for `attr` tag and parent in traversal context is no longer necessary.

Skip verbose fields like connection string from attributes.