### PR TITLE
Fix bug where struct slice elements were not being reported

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -152,20 +152,18 @@ func populateObservables(ctx context.Context, tctx traversalContext, observables
 				return
 			}
 		}
-		elems, ok := tctx.field.Interface().([]any)
-		if ok {
-			for _, elem := range elems {
-				select {
-				case <-ctx.Done():
-					return
-				default:
-					populateObservables(ctx, traversalContext{
-						field:      reflect.ValueOf(elem),
-						metricName: tctx.metricName,
-						attrs:      tctx.attrs,
-						tag:        tctx.tag,
-					}, observables, commonAttrs)
-				}
+		elems := reflect.ValueOf(tctx.field.Interface())
+		for i := 0; i < elems.Len(); i++ {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				populateObservables(ctx, traversalContext{
+					field:      elems.Index(i),
+					metricName: tctx.metricName,
+					attrs:      tctx.attrs,
+					tag:        tctx.tag,
+				}, observables, commonAttrs)
 			}
 		}
 	case reflect.Map:


### PR DESCRIPTION
Fix a bug where the iterator did not iterate correctly over slice elements of type struct. Add tests that assert corresponding metrics are reported with expected attributes.

Additionally, assert that collected values do not contain duplicates.