### PR TITLE
Upgrade to FoundationDB 7.3.7 and use 730 as default API version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20-bullseye as build
 
-ARG FDB_VERSION='7.1.33'
-ARG FDB_CLIENTS_DEB_SHA256_SUM='d73002bc796de7ce0158f1eb64fab1f8e90bada2edd90599d9b40754220150af'
+ARG FDB_VERSION='7.3.7'
+ARG FDB_CLIENTS_DEB_SHA256_SUM='1b620971319c3ad149f2fb09b2fed639fb558120a296538133c4f2358836e983'
 RUN wget "https://github.com/apple/foundationdb/releases/download/${FDB_VERSION}/foundationdb-clients_${FDB_VERSION}-1_amd64.deb" && \
     echo "${FDB_CLIENTS_DEB_SHA256_SUM}  foundationdb-clients_${FDB_VERSION}-1_amd64.deb" | sha256sum --check && \
     dpkg --force-all -i foundationdb-clients_${FDB_VERSION}-1_amd64.deb

--- a/cmd/fdbmeter/main.go
+++ b/cmd/fdbmeter/main.go
@@ -15,10 +15,10 @@ import (
 
 func main() {
 	httpListenAddr := flag.String("httpListenAddr", "0.0.0.0:40080", "The bind address of fdbmeter HTTP server.")
-	fdbApiVersion := flag.Int("fdbApiVersion", 710, "The FoundationDB API version.")
+	fdbApiVersion := flag.Int("fdbApiVersion", 730, "The FoundationDB API version.")
 	fdbClusterFile := flag.String("fdbClusterFile", "", "Path to the FoundationDB cluster file.")
 	statusRefreshInterval := flag.Duration("statusRefreshInterval", 10*time.Second, "The interval at which to refresh the FoundationDB status.")
-	commonAttributes := flag.String("commonAttributes", "", "The common attributes to apply to all metrices specified as comma separated key=value.")
+	commonAttributes := flag.String("commonAttributes", "", "The common attributes to apply to all metrics specified as comma separated key=value.")
 	flag.Parse()
 
 	var commonAttrs []attribute.KeyValue


### PR DESCRIPTION
Upgrade to the latest tagged release of FoundationDB and change the default API version to 730.